### PR TITLE
Maintain backwards compatibility for pytest 4.x

### DIFF
--- a/src/pytest_cython/plugin.py
+++ b/src/pytest_cython/plugin.py
@@ -67,7 +67,11 @@ def pytest_collect_file(path, parent):
             # only run test if matching .so and .pyx files exist
             # create addoption for this ??
             if pyx_file is not None:
-                return DoctestModule.from_parent(parent, fspath=path)
+                if hasattr(DoctestModule, 'from_parent'):
+                    return DoctestModule.from_parent(parent, fspath=path)
+                else:
+                    # Backwards-compat for older pytest
+                    return DoctestModule(path, parent)
 
 
 # XXX patch pyimport to support PEP 3149
@@ -117,7 +121,12 @@ class DoctestModule(pytest.Module):
                                      checker=checker)
         for test in finder.find(module, module.__name__):
             if test.examples:  # skip empty doctests
-                yield DoctestItem.from_parent(self, name=test.name, runner=runner, dtest=test)
+                if hasattr(DoctestItem, 'from_parent'):
+                    yield DoctestItem.from_parent(self, name=test.name,
+                                                  runner=runner, dtest=test)
+                else:
+                    # Backwards-compat for older pytest
+                    yield DoctestItem(test.name, self, runner, test)
 
     def _importtestmodule(self):
         # we assume we are only called once per module


### PR DESCRIPTION
As long as v0.1.x of this plugin maintains Python 2 support (which should be dropped in a later release) the most recent pytest versions supported on Python 2 are 4.6.x.  So this should go hand-in-hand with #5 to support both newer and older versions simultaneously.

I found this while updating the tox environments, and with this found that the tests will pass on Python 2 with pytest 4.6.