### PR TITLE
Add support for Windows/Cygwin.

### DIFF
--- a/src/pytest_cython/plugin.py
+++ b/src/pytest_cython/plugin.py
@@ -48,7 +48,7 @@ def _find_matching_pyx_file(path, extensions):
 
 
 def pytest_collect_file(path, parent):
-    bin_exts = ['.so']
+    bin_exts = ['.so', '.dll']
     cy_exts = ['.pyx', '.py']  # collect .so files if .py file exists
     ext_suffix = sysconfig.get_config_var("EXT_SUFFIX")
 


### PR DESCRIPTION
This just means accepting .dll as a possible extension module file
extension.  Everything else works as-is.