### PR TITLE
Drop python2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,8 @@ jobs:
           env: TOXENV=py38-54-029
         - python: "3.8"
           env: TOXENV=py38-62-029
-        - python: "pypy"
-          env: TOXENV=pypy-46-029
+        - python: "pypy3"
+          env: TOXENV=pypy3-46-029
 before_install:
   - python --version
   - uname -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,6 @@ jobs:
     include:
         - python: "3.7"
           env: TOXENV=check
-        - python: "2.7"
-          env: TOXENV=py27-46-028
-        - python: "2.7"
-          env: TOXENV=py27-46-029
         - python: "3.6"
           env: TOXENV=py36-46-028
         - python: "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,27 +10,7 @@ jobs:
         - python: "3.7"
           env: TOXENV=check
         - python: "3.6"
-          env: TOXENV=py36-46-028
-        - python: "3.6"
-          env: TOXENV=py36-46-029
-        - python: "3.6"
-          env: TOXENV=py36-54-028
-        - python: "3.6"
-          env: TOXENV=py36-54-029
-        - python: "3.6"
-          env: TOXENV=py36-62-028
-        - python: "3.6"
           env: TOXENV=py36-62-029
-        - python: "3.7"
-          env: TOXENV=py37-46-028
-        - python: "3.7"
-          env: TOXENV=py37-46-029
-        - python: "3.7"
-          env: TOXENV=py37-54-028
-        - python: "3.7"
-          env: TOXENV=py37-54-029
-        - python: "3.7"
-          env: TOXENV=py37-62-028
         - python: "3.7"
           env: TOXENV=py37-62-029
         - python: "3.8"
@@ -40,7 +20,7 @@ jobs:
         - python: "3.8"
           env: TOXENV=py38-62-029
         - python: "pypy3"
-          env: TOXENV=pypy3-46-029
+          env: TOXENV=pypy3-62-029
 before_install:
   - python --version
   - uname -a

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,236 +7,26 @@ environment:
     WITH_COMPILER: 'cmd /E:ON /V:ON /C .\ci\appveyor-with-compiler.cmd'
   matrix:
     - TOXENV: check
-      PYTHON_HOME: C:\Python27
-      PYTHON_VERSION: '2.7'
-      PYTHON_ARCH: '32'
-
-    - TOXENV: 'py27-27-023'
-      TOXPYTHON: C:\Python27\python.exe
-      PYTHON_HOME: C:\Python27
-      PYTHON_VERSION: '2.7'
-      PYTHON_ARCH: '32'
-
-    - TOXENV: 'py27-27-023'
-      TOXPYTHON: C:\Python27-x64\python.exe
-      WINDOWS_SDK_VERSION: v7.0
-      PYTHON_HOME: C:\Python27-x64
-      PYTHON_VERSION: '2.7'
+      PYTHON_HOME: C:\Python37
+      PYTHON_VERSION: '3.7'
       PYTHON_ARCH: '64'
 
-    - TOXENV: 'py27-27-024'
-      TOXPYTHON: C:\Python27\python.exe
-      PYTHON_HOME: C:\Python27
-      PYTHON_VERSION: '2.7'
-      PYTHON_ARCH: '32'
-
-    - TOXENV: 'py27-27-024'
-      TOXPYTHON: C:\Python27-x64\python.exe
-      WINDOWS_SDK_VERSION: v7.0
-      PYTHON_HOME: C:\Python27-x64
-      PYTHON_VERSION: '2.7'
+    - TOXENV: 'py36-62-029'
+      TOXPYTHON: C:\Python36-x64\python.exe
+      PYTHON_HOME: C:\Python36-x64
+      PYTHON_VERSION: '3.6'
       PYTHON_ARCH: '64'
 
-    - TOXENV: 'py27-28-023'
-      TOXPYTHON: C:\Python27\python.exe
-      PYTHON_HOME: C:\Python27
-      PYTHON_VERSION: '2.7'
-      PYTHON_ARCH: '32'
-
-    - TOXENV: 'py27-28-023'
-      TOXPYTHON: C:\Python27-x64\python.exe
-      WINDOWS_SDK_VERSION: v7.0
-      PYTHON_HOME: C:\Python27-x64
-      PYTHON_VERSION: '2.7'
+    - TOXENV: 'py37-62-029'
+      TOXPYTHON: C:\Python37-x64\python.exe
+      PYTHON_HOME: C:\Python37-x64
+      PYTHON_VERSION: '3.7'
       PYTHON_ARCH: '64'
 
-    - TOXENV: 'py27-28-024'
-      TOXPYTHON: C:\Python27\python.exe
-      PYTHON_HOME: C:\Python27
-      PYTHON_VERSION: '2.7'
-      PYTHON_ARCH: '32'
-
-    - TOXENV: 'py27-28-024'
-      TOXPYTHON: C:\Python27-x64\python.exe
-      WINDOWS_SDK_VERSION: v7.0
-      PYTHON_HOME: C:\Python27-x64
-      PYTHON_VERSION: '2.7'
-      PYTHON_ARCH: '64'
-
-    - TOXENV: 'py27-29-023'
-      TOXPYTHON: C:\Python27\python.exe
-      PYTHON_HOME: C:\Python27
-      PYTHON_VERSION: '2.7'
-      PYTHON_ARCH: '32'
-
-    - TOXENV: 'py27-29-023'
-      TOXPYTHON: C:\Python27-x64\python.exe
-      WINDOWS_SDK_VERSION: v7.0
-      PYTHON_HOME: C:\Python27-x64
-      PYTHON_VERSION: '2.7'
-      PYTHON_ARCH: '64'
-
-    - TOXENV: 'py27-29-024'
-      TOXPYTHON: C:\Python27\python.exe
-      PYTHON_HOME: C:\Python27
-      PYTHON_VERSION: '2.7'
-      PYTHON_ARCH: '32'
-
-    - TOXENV: 'py27-29-024'
-      TOXPYTHON: C:\Python27-x64\python.exe
-      WINDOWS_SDK_VERSION: v7.0
-      PYTHON_HOME: C:\Python27-x64
-      PYTHON_VERSION: '2.7'
-      PYTHON_ARCH: '64'
-
-    - TOXENV: 'py34-27-023'
-      TOXPYTHON: C:\Python34\python.exe
-      PYTHON_HOME: C:\Python34
-      PYTHON_VERSION: '3.4'
-      PYTHON_ARCH: '32'
-
-    - TOXENV: 'py34-27-023'
-      TOXPYTHON: C:\Python34-x64\python.exe
-      WINDOWS_SDK_VERSION: v7.1
-      PYTHON_HOME: C:\Python34-x64
-      PYTHON_VERSION: '3.4'
-      PYTHON_ARCH: '64'
-
-    - TOXENV: 'py34-27-024'
-      TOXPYTHON: C:\Python34\python.exe
-      PYTHON_HOME: C:\Python34
-      PYTHON_VERSION: '3.4'
-      PYTHON_ARCH: '32'
-
-    - TOXENV: 'py34-27-024'
-      TOXPYTHON: C:\Python34-x64\python.exe
-      WINDOWS_SDK_VERSION: v7.1
-      PYTHON_HOME: C:\Python34-x64
-      PYTHON_VERSION: '3.4'
-      PYTHON_ARCH: '64'
-
-    - TOXENV: 'py34-28-023'
-      TOXPYTHON: C:\Python34\python.exe
-      PYTHON_HOME: C:\Python34
-      PYTHON_VERSION: '3.4'
-      PYTHON_ARCH: '32'
-
-    - TOXENV: 'py34-28-023'
-      TOXPYTHON: C:\Python34-x64\python.exe
-      WINDOWS_SDK_VERSION: v7.1
-      PYTHON_HOME: C:\Python34-x64
-      PYTHON_VERSION: '3.4'
-      PYTHON_ARCH: '64'
-
-    - TOXENV: 'py34-28-024'
-      TOXPYTHON: C:\Python34\python.exe
-      PYTHON_HOME: C:\Python34
-      PYTHON_VERSION: '3.4'
-      PYTHON_ARCH: '32'
-
-    - TOXENV: 'py34-28-024'
-      TOXPYTHON: C:\Python34-x64\python.exe
-      WINDOWS_SDK_VERSION: v7.1
-      PYTHON_HOME: C:\Python34-x64
-      PYTHON_VERSION: '3.4'
-      PYTHON_ARCH: '64'
-
-    - TOXENV: 'py34-29-023'
-      TOXPYTHON: C:\Python34\python.exe
-      PYTHON_HOME: C:\Python34
-      PYTHON_VERSION: '3.4'
-      PYTHON_ARCH: '32'
-
-    - TOXENV: 'py34-29-023'
-      TOXPYTHON: C:\Python34-x64\python.exe
-      WINDOWS_SDK_VERSION: v7.1
-      PYTHON_HOME: C:\Python34-x64
-      PYTHON_VERSION: '3.4'
-      PYTHON_ARCH: '64'
-
-    - TOXENV: 'py34-29-024'
-      TOXPYTHON: C:\Python34\python.exe
-      PYTHON_HOME: C:\Python34
-      PYTHON_VERSION: '3.4'
-      PYTHON_ARCH: '32'
-
-    - TOXENV: 'py34-29-024'
-      TOXPYTHON: C:\Python34-x64\python.exe
-      WINDOWS_SDK_VERSION: v7.1
-      PYTHON_HOME: C:\Python34-x64
-      PYTHON_VERSION: '3.4'
-      PYTHON_ARCH: '64'
-
-    - TOXENV: 'py35-27-023'
-      TOXPYTHON: C:\Python35\python.exe
-      PYTHON_HOME: C:\Python35
-      PYTHON_VERSION: '3.5'
-      PYTHON_ARCH: '32'
-
-    - TOXENV: 'py35-27-023'
-      TOXPYTHON: C:\Python35-x64\python.exe
-      PYTHON_HOME: C:\Python35-x64
-      PYTHON_VERSION: '3.5'
-      PYTHON_ARCH: '64'
-
-    - TOXENV: 'py35-27-024'
-      TOXPYTHON: C:\Python35\python.exe
-      PYTHON_HOME: C:\Python35
-      PYTHON_VERSION: '3.5'
-      PYTHON_ARCH: '32'
-
-    - TOXENV: 'py35-27-024'
-      TOXPYTHON: C:\Python35-x64\python.exe
-      PYTHON_HOME: C:\Python35-x64
-      PYTHON_VERSION: '3.5'
-      PYTHON_ARCH: '64'
-
-    - TOXENV: 'py35-28-023'
-      TOXPYTHON: C:\Python35\python.exe
-      PYTHON_HOME: C:\Python35
-      PYTHON_VERSION: '3.5'
-      PYTHON_ARCH: '32'
-
-    - TOXENV: 'py35-28-023'
-      TOXPYTHON: C:\Python35-x64\python.exe
-      PYTHON_HOME: C:\Python35-x64
-      PYTHON_VERSION: '3.5'
-      PYTHON_ARCH: '64'
-
-    - TOXENV: 'py35-28-024'
-      TOXPYTHON: C:\Python35\python.exe
-      PYTHON_HOME: C:\Python35
-      PYTHON_VERSION: '3.5'
-      PYTHON_ARCH: '32'
-
-    - TOXENV: 'py35-28-024'
-      TOXPYTHON: C:\Python35-x64\python.exe
-      PYTHON_HOME: C:\Python35-x64
-      PYTHON_VERSION: '3.5'
-      PYTHON_ARCH: '64'
-
-    - TOXENV: 'py35-29-023'
-      TOXPYTHON: C:\Python35\python.exe
-      PYTHON_HOME: C:\Python35
-      PYTHON_VERSION: '3.5'
-      PYTHON_ARCH: '32'
-
-    - TOXENV: 'py35-29-023'
-      TOXPYTHON: C:\Python35-x64\python.exe
-      PYTHON_HOME: C:\Python35-x64
-      PYTHON_VERSION: '3.5'
-      PYTHON_ARCH: '64'
-
-    - TOXENV: 'py35-29-024'
-      TOXPYTHON: C:\Python35\python.exe
-      PYTHON_HOME: C:\Python35
-      PYTHON_VERSION: '3.5'
-      PYTHON_ARCH: '32'
-
-    - TOXENV: 'py35-29-024'
-      TOXPYTHON: C:\Python35-x64\python.exe
-      PYTHON_HOME: C:\Python35-x64
-      PYTHON_VERSION: '3.5'
+    - TOXENV: 'py38-62-029'
+      TOXPYTHON: C:\Python38-x64\python.exe
+      PYTHON_HOME: C:\Python38-x64
+      PYTHON_VERSION: '3.8'
       PYTHON_ARCH: '64'
 
 init:

--- a/ci/appveyor-bootstrap.py
+++ b/ci/appveyor-bootstrap.py
@@ -21,29 +21,15 @@ BASE_URL = "https://www.python.org/ftp/python/"
 GET_PIP_URL = "https://bootstrap.pypa.io/get-pip.py"
 GET_PIP_PATH = "C:\get-pip.py"
 URLS = {
-    ("2.6", "64"): BASE_URL + "2.6.6/python-2.6.6.amd64.msi",
-    ("2.6", "32"): BASE_URL + "2.6.6/python-2.6.6.msi",
-    ("2.7", "64"): BASE_URL + "2.7.10/python-2.7.10.amd64.msi",
-    ("2.7", "32"): BASE_URL + "2.7.10/python-2.7.10.msi",
-    # NOTE: no .msi installer for 3.3.6
-    ("3.3", "64"): BASE_URL + "3.3.3/python-3.3.3.amd64.msi",
-    ("3.3", "32"): BASE_URL + "3.3.3/python-3.3.3.msi",
-    ("3.4", "64"): BASE_URL + "3.4.3/python-3.4.3.amd64.msi",
-    ("3.4", "32"): BASE_URL + "3.4.3/python-3.4.3.msi",
-    ("3.5", "64"): BASE_URL + "3.5.0/python-3.5.0-amd64.exe",
-    ("3.5", "32"): BASE_URL + "3.5.0/python-3.5.0.exe",
+    ("3.6", "64"): BASE_URL + "3.6.8/python-3.6.8-amd64.exe",
+    ("3.7", "64"): BASE_URL + "3.7.9/python-3.7.9-amd64.exe",
+    ("3.8", "64"): BASE_URL + "3.8.8/python-3.8.8-amd64.exe",
 }
 INSTALL_CMD = {
     # Commands are allowed to fail only if they are not the last command.  Eg: uninstall (/x) allowed to fail.
-    "2.6": [["msiexec.exe", "/L*+!", "install.log", "/qn", "/x", "{path}"],
-            ["msiexec.exe", "/L*+!", "install.log", "/qn", "/i", "{path}", "TARGETDIR={home}"]],
-    "2.7": [["msiexec.exe", "/L*+!", "install.log", "/qn", "/x", "{path}"],
-            ["msiexec.exe", "/L*+!", "install.log", "/qn", "/i", "{path}", "TARGETDIR={home}"]],
-    "3.3": [["msiexec.exe", "/L*+!", "install.log", "/qn", "/x", "{path}"],
-            ["msiexec.exe", "/L*+!", "install.log", "/qn", "/i", "{path}", "TARGETDIR={home}"]],
-    "3.4": [["msiexec.exe", "/L*+!", "install.log", "/qn", "/x", "{path}"],
-            ["msiexec.exe", "/L*+!", "install.log", "/qn", "/i", "{path}", "TARGETDIR={home}"]],
-    "3.5": [["{path}", "/quiet", "TargetDir={home}"]],
+    "3.6": [["{path}", "/quiet", "TargetDir={home}"]],
+    "3.7": [["{path}", "/quiet", "TargetDir={home}"]],
+    "3.8": [["{path}", "/quiet", "TargetDir={home}"]],
 }
 
 

--- a/ci/templates/appveyor.yml
+++ b/ci/templates/appveyor.yml
@@ -7,20 +7,14 @@ environment:
     WITH_COMPILER: 'cmd /E:ON /V:ON /C .\ci\appveyor-with-compiler.cmd'
   matrix:
     - TOXENV: check
-      PYTHON_HOME: C:\Python27
-      PYTHON_VERSION: '2.7'
-      PYTHON_ARCH: '32'
+      PYTHON_HOME: C:\Python37-x64
+      PYTHON_VERSION: '3.7'
+      PYTHON_ARCH: '64'
 
-{% for env in tox_environments %}{% if env.startswith(('py27', 'py34', 'py35')) %}
-    - TOXENV: '{{ env }}{% if 'cover' in env %},codecov{% endif %}'
-      TOXPYTHON: C:\Python{{ env[2:4] }}\python.exe
-      PYTHON_HOME: C:\Python{{ env[2:4] }}
-      PYTHON_VERSION: '{{ env[2] }}.{{ env[3] }}'
-      PYTHON_ARCH: '32'
-
+{% for env in tox_environments %}{% if env.startswith(('py36', 'py37', 'py38')) %}
     - TOXENV: '{{ env }}{% if 'cover' in env %},codecov{% endif %}'
       TOXPYTHON: C:\Python{{ env[2:4] }}-x64\python.exe
-      {%- if env.startswith(('py2', 'py33', 'py34')) %}
+      {%- if env.startswith(('py36', 'py37', 'py38')) %}
 
       WINDOWS_SDK_VERSION: v7.{{ '1' if env.startswith('py3') else '0' }}
       {%- endif %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import os
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,5 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import print_function
-
 from glob import glob
 from os import path
 

--- a/setup.py
+++ b/setup.py
@@ -39,12 +39,10 @@ setup(
         'Operating System :: POSIX',
         # 'Operating System :: Microsoft :: Windows',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         # uncomment if you test on these interpreters:
@@ -58,7 +56,7 @@ setup(
         'pytest', 'py.test', 'cython', 'doctest',
     ],
     install_requires=[
-        'pytest>=2.7.3',
+        'pytest>=4.6.0',
     ],
     extras_require={
     },

--- a/src/pytest_cython/plugin.py
+++ b/src/pytest_cython/plugin.py
@@ -1,16 +1,9 @@
 """ discover and run doctests in Cython extension modules."""
-from __future__ import absolute_import
 
-import keyword
-import re
 import sys
-import tokenize
-import pytest
+import sysconfig
 
-try:
-    import sysconfig
-except ImportError:
-    from distutils import sysconfig
+import pytest
 
 import _pytest
 from _pytest.doctest import get_optionflags
@@ -77,13 +70,7 @@ def pytest_collect_file(path, parent):
                     return DoctestModule(path, parent)
 
 
-# XXX if python2 support is dropped just use str.isidentifier
-def _isidentifier(s):
-    return (re.match('^' + tokenize.Name + '$', s)
-            and not keyword.iskeyword(s))
-
-
-# XXX copied from pytest but modified to use py.path instead; if Python 2
+# XXX copied from pytest but modified to use py.path instead; if pytest<6.0
 # support is dropped and support for more modern pytest added we can just use
 # the one from pytest
 def _resolve_package_path(path):
@@ -97,7 +84,7 @@ def _resolve_package_path(path):
         if parent.isdir():
             if not parent.join('__init__.py').isfile():
                 break
-            if not _isidentifier(parent.basename):
+            if not parent.basename.isidentifier():
                 break
             result = parent
     return result

--- a/tests/example-project/setup.py
+++ b/tests/example-project/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- encoding: utf-8 -*-
-from __future__ import absolute_import
 
 
 if __name__ == "__main__":

--- a/tests/test_pytest_cython.py
+++ b/tests/test_pytest_cython.py
@@ -11,20 +11,7 @@ import pytest_cython.plugin
 
 PATH = py.path.local(__file__).dirpath()
 PATH = PATH.join('example-project', 'src', 'pypackage')
-
-try:
-    import __pypy__
-    import imp
-    # Suffix will be something like pypy-N.so; this is how pypy's own distutils
-    # patch does this...
-    for ext in imp.get_suffixes():
-        if ext[2] == imp.C_EXTENSION:
-            EXT_SUFFIX = ext[0]
-            break
-    else:
-        EXT_SUFFIX = '.so'
-except ImportError:
-    EXT_SUFFIX = sysconfig.get_config_var("EXT_SUFFIX") or '.so'
+EXT_SUFFIX = sysconfig.get_config_var("EXT_SUFFIX") or '.so'
 
 
 def get_module(basename, suffix=EXT_SUFFIX):

--- a/tox.ini
+++ b/tox.ini
@@ -5,13 +5,13 @@ envlist =
     check
     {py36,py37}-{46,54,62}-{028,029}
     py38-{46,54,62}-029
-    pypy-46-029
+    pypy3-46-029
     docs
     spell
 
 [testenv]
 basepython =
-    pypy: pypy
+    pypy3: pypy3
     {docs}: {env:TOXPYTHON:python3.7}
     py36: {env:TOXPYTHON:python3.6}
     py37: {env:TOXPYTHON:python3.7}

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@
 [tox]
 envlist =
     check
-    py27-46-{028,029}
     {py36,py37}-{46,54,62}-{028,029}
     py38-{46,54,62}-029
     pypy-46-029
@@ -13,7 +12,7 @@ envlist =
 [testenv]
 basepython =
     pypy: pypy
-    {py27,docs}: {env:TOXPYTHON:python2.7}
+    {docs}: {env:TOXPYTHON:python3.7}
     py36: {env:TOXPYTHON:python3.6}
     py37: {env:TOXPYTHON:python3.7}
     py38: {env:TOXPYTHON:python3.8}


### PR DESCRIPTION
Part of the checklist in #14.  Removes all the obvious minimal bits needed for Python 2 support.