### PR TITLE
Add Python 3.9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,13 @@ jobs:
         - python: "3.7"
           env: TOXENV=py37-62-029
         - python: "3.8"
-          env: TOXENV=py38-46-029
-        - python: "3.8"
-          env: TOXENV=py38-54-029
-        - python: "3.8"
           env: TOXENV=py38-62-029
+        - python: "3.9"
+          env: TOXENV=py39-46-029
+        - python: "3.9"
+          env: TOXENV=py39-54-029
+        - python: "3.9"
+          env: TOXENV=py39-62-029
         - python: "pypy3"
           env: TOXENV=pypy3-62-029
 before_install:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
 import os
+import sys
+
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 
 extensions = [
@@ -20,11 +24,13 @@ if os.getenv('SPELLCHECK'):
 
 source_suffix = '.rst'
 master_doc = 'index'
-project = u'pytest-cython'
-year = '2016'
-author = u'Logan Page'
+project = 'pytest-cython'
+year = '2021'
+author = 'Logan Page'
 copyright = '{0}, {1}'.format(year, author)
-version = release = u'0.1.1'
+
+
+from pytest_cython import __version__ as release
 
 pygments_style = 'trac'
 templates_path = ['.']
@@ -45,7 +51,7 @@ html_split_index = True
 html_sidebars = {
    '**': ['searchbox.html', 'globaltoc.html', 'sourcelink.html'],
 }
-html_short_title = '%s-%s' % (project, version)
+html_short_title = f'{project}-{release}'
 
 napoleon_use_ivar = True
 napoleon_use_rtype = False

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -10,8 +10,10 @@ classmethods
 cython
 docstrings
 doctesting
+embray
 inplace
 kwargs
 pytest
 staticmethod
 staticmethods
+thrasibule

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,10 +37,12 @@ addopts =
 # 2) ignore DeprecationWarning from Cython 0.28 on newer Python versions
 # 3) ignore PytestDeprecationWarning caused by a bug in pytest itself when
 #    using pytester: https://github.com/pytest-dev/pytest/issues/6936
+# 4) ignore PendingDeprecationWarning from setuptools
 filterwarnings =
     ignore:the imp module is deprecated in favour of importlib
     ignore:Using or importing the ABCs from 'collections'
     ignore:The TerminalReporter.writer attribute is deprecated
+    ignore:lib2to3 package is deprecated
 
 [isort]
 force_single_line=True

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         # uncomment if you test on these interpreters:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,9 @@ from os import path
 from setuptools import find_packages
 from setuptools import setup
 
+
 this_directory = path.abspath(path.dirname(__file__))
+
 
 with open(path.join(this_directory, 'README.rst')) as readme_file:
     long_description = readme_file.read()
@@ -14,7 +16,7 @@ with open(path.join(this_directory, 'README.rst')) as readme_file:
 
 setup(
     name='pytest-cython',
-    version='0.1.1.post0',
+    version='0.2.dev0',
     description='A plugin for testing Cython extension modules',
     long_description=long_description,
     long_description_content_type='text/x-rst',
@@ -55,10 +57,6 @@ setup(
     install_requires=[
         'pytest>=4.6.0',
     ],
-    extras_require={
-    },
-    cmdclass={
-    },
     entry_points={
         'pytest11': [
             'pytest_cython = pytest_cython.plugin',

--- a/src/pytest_cython/__init__.py
+++ b/src/pytest_cython/__init__.py
@@ -1,1 +1,9 @@
-__version__ = "0.1.1"
+try:
+    from pkg_resources import get_distribution
+    __version__ = get_distribution('pytest-cython').version
+    del get_distribution
+except Exception:
+    import warnings
+    warnings.warn('could not get pytest-cython version; pkg_resources '
+                  'not available or package not installed')
+    __version__ = '0.0.0'

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 envlist =
     check
     {py36,py37}-{46,54,62}-{028,029}
-    py38-{46,54,62}-029
+    {py38,py39}-{46,54,62}-029
     pypy3-46-029
     docs
     spell
@@ -16,6 +16,7 @@ basepython =
     py36: {env:TOXPYTHON:python3.6}
     py37: {env:TOXPYTHON:python3.7}
     py38: {env:TOXPYTHON:python3.8}
+    py39: {env:TOXPYTHON:python3.9}
     {clean,check,report,extension-coveralls,coveralls,spell}: python3.7
 setenv =
     PYTHONPATH = {toxinidir}/tests


### PR DESCRIPTION
Not much to do here except update the testing-related files to demonstrate that Python 3.9 works.

This is a follow-on to #16 and closes #14.