### PR TITLE
New patched pyimport implementation

### DIFF
--- a/tests/test_pytest_cython.py
+++ b/tests/test_pytest_cython.py
@@ -18,6 +18,11 @@ def get_module(basename, suffix=EXT_SUFFIX):
     return PATH.join(basename + suffix)
 
 
+def run_pytest(testdir, module, import_mode):
+    return testdir.runpytest('-vv', '--doctest-cython',
+                             '--import-mode', import_mode, str(module))
+
+
 @pytest.fixture(scope='module', autouse=True)
 def build_example_project():
     path = py.path.local(__file__).dirpath()
@@ -25,10 +30,11 @@ def build_example_project():
     run_setup(str(setup_py), ['build_ext', '--inplace'])
 
 
-def test_cython_ext_module(testdir):
+@pytest.mark.parametrize('import_mode', ('importlib', 'prepend', 'append'))
+def test_cython_ext_module(testdir, import_mode):
     module = get_module('cython_ext_module')
     assert module.check()
-    result = testdir.runpytest('-vv', '--doctest-cython', str(module))
+    result = run_pytest(testdir, module, import_mode)
     result.stdout.fnmatch_lines([
         "*Eggs.__init__ *PASSED*",
         "*Eggs.blarg*PASSED*",
@@ -37,30 +43,33 @@ def test_cython_ext_module(testdir):
     assert result.ret == 0
 
 
-def test_wrap_c_ext_module(testdir):
+@pytest.mark.parametrize('import_mode', ('importlib', 'prepend', 'append'))
+def test_wrap_c_ext_module(testdir, import_mode):
     module = get_module('wrap_c_ext_module')
     assert module.check()
-    result = testdir.runpytest('-vv', '--doctest-cython', str(module))
+    result = run_pytest(testdir, module, import_mode)
     result.stdout.fnmatch_lines([
         "*sqr*PASSED*",
     ])
     assert result.ret == 0
 
 
-def test_wrap_cpp_ext_module(testdir):
+@pytest.mark.parametrize('import_mode', ('importlib', 'prepend', 'append'))
+def test_wrap_cpp_ext_module(testdir, import_mode):
     module = get_module('wrap_cpp_ext_module')
     assert module.check()
-    result = testdir.runpytest('-vv', '--doctest-cython', str(module))
+    result = run_pytest(testdir, module, import_mode)
     result.stdout.fnmatch_lines([
         "*sqr*PASSED*",
     ])
     assert result.ret == 0
 
 
-def test_pure_py_module(testdir):
+@pytest.mark.parametrize('import_mode', ('importlib', 'prepend', 'append'))
+def test_pure_py_module(testdir, import_mode):
     module = get_module('pure_py_module', suffix='.py')
     assert module.check()
-    result = testdir.runpytest('-vv', '--doctest-cython', str(module))
+    result = run_pytest(testdir, module, import_mode)
     result.stdout.fnmatch_lines([
         "*Eggs.__init__*PASSED*",
         "*Eggs.foo*PASSED*",

--- a/tests/test_pytest_cython.py
+++ b/tests/test_pytest_cython.py
@@ -13,6 +13,11 @@ PATH = py.path.local(__file__).dirpath()
 PATH = PATH.join('example-project', 'src', 'pypackage')
 EXT_SUFFIX = sysconfig.get_config_var("EXT_SUFFIX") or '.so'
 
+PYTEST_MAJOR_VERSION = int(pytest.__version__.split('.')[0])
+IMPORT_MODES = ['prepend', 'append']
+if PYTEST_MAJOR_VERSION >= 6:
+    IMPORT_MODES.insert(0, 'importlib')
+
 
 def get_module(basename, suffix=EXT_SUFFIX):
     return PATH.join(basename + suffix)
@@ -30,7 +35,7 @@ def build_example_project():
     run_setup(str(setup_py), ['build_ext', '--inplace'])
 
 
-@pytest.mark.parametrize('import_mode', ('importlib', 'prepend', 'append'))
+@pytest.mark.parametrize('import_mode', IMPORT_MODES)
 def test_cython_ext_module(testdir, import_mode):
     module = get_module('cython_ext_module')
     assert module.check()
@@ -43,7 +48,7 @@ def test_cython_ext_module(testdir, import_mode):
     assert result.ret == 0
 
 
-@pytest.mark.parametrize('import_mode', ('importlib', 'prepend', 'append'))
+@pytest.mark.parametrize('import_mode', IMPORT_MODES)
 def test_wrap_c_ext_module(testdir, import_mode):
     module = get_module('wrap_c_ext_module')
     assert module.check()
@@ -54,7 +59,7 @@ def test_wrap_c_ext_module(testdir, import_mode):
     assert result.ret == 0
 
 
-@pytest.mark.parametrize('import_mode', ('importlib', 'prepend', 'append'))
+@pytest.mark.parametrize('import_mode', IMPORT_MODES)
 def test_wrap_cpp_ext_module(testdir, import_mode):
     module = get_module('wrap_cpp_ext_module')
     assert module.check()
@@ -65,7 +70,7 @@ def test_wrap_cpp_ext_module(testdir, import_mode):
     assert result.ret == 0
 
 
-@pytest.mark.parametrize('import_mode', ('importlib', 'prepend', 'append'))
+@pytest.mark.parametrize('import_mode', IMPORT_MODES)
 def test_pure_py_module(testdir, import_mode):
     module = get_module('pure_py_module', suffix='.py')
     assert module.check()


### PR DESCRIPTION
As noted in the commit messages, this re-implements the workaround for importing extensions modules, so that rather than having to copy the existing code of `py.path.pyimport` (or the equivalent `import_path` function that is used in pytest 6.0+) it instead wraps the existing functions and adds some hacked path objects that are tweaked so that the way pytest computes the module name will still work for extension modules.

This could be a bit fragile, but it will work for older pytest versions as this code is not likely to change much.  For future versions I hope to get this fixed upstream.