### PR TITLE
Rework how test collection works

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,9 +112,6 @@ This `Pytest`_ plugin was generated with `Cookiecutter`_ along with
 .. _`@hackebrot`: https://github.com/hackebrot
 .. _`@ionelmc`: https://github.com/ionelmc
 .. _`MIT`: https://opensource.org/licenses/MIT
-.. _`BSD-3`: https://opensource.org/licenses/BSD-3-Clause
-.. _`GNU GPL v3.0`: https://www.gnu.org/licenses/gpl-3.0.txt
-.. _`Apache Software License 2.0`: https://www.apache.org/licenses/LICENSE-2.0
 .. _`cookiecutter-pytest-plugin`: https://github.com/pytest-dev/cookiecutter-pytest-plugin
 .. _`cookiecutter-pylibrary`: https://github.com/ionelmc/cookiecutter-pylibrary
 .. _`file an issue`: https://github.com/lgpage/pytest-cython/issues
@@ -123,4 +120,3 @@ This `Pytest`_ plugin was generated with `Cookiecutter`_ along with
 .. _`pip`: https://pypi.org/project/pip/
 .. _`PyPI`: https://pypi.org
 .. _`Cython`: https://cython.org/
-.. _`Cython compiler directive`: https://docs.cython.org/en/latest/src/reference/compilation.html#compiler-directives

--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,6 @@ Note
 
 * It is assumed that the C extension modules have been build inplace before
   running `py.test` and there is a matching Cython `.pyx` file
-* The `embedsignature` `Cython compiler directive`_ must be set to `True`
 
 
 Contributing

--- a/tests/example-project/setup.py
+++ b/tests/example-project/setup.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
 
     directives = {
         'profile': True,
-        'embedsignature': True,
+        'embedsignature': False,
         'linetrace': False,
         'language_level': sys.version_info[0]
     }

--- a/tests/test_pytest_cython.py
+++ b/tests/test_pytest_cython.py
@@ -11,7 +11,6 @@ import pytest_cython.plugin
 
 PATH = py.path.local(__file__).dirpath()
 PATH = PATH.join('example-project', 'src', 'pypackage')
-EXT_SUFFIX = sysconfig.get_config_var("EXT_SUFFIX") or '.so'
 
 PYTEST_MAJOR_VERSION = int(pytest.__version__.split('.')[0])
 IMPORT_MODES = ['prepend', 'append']
@@ -19,7 +18,7 @@ if PYTEST_MAJOR_VERSION >= 6:
     IMPORT_MODES.insert(0, 'importlib')
 
 
-def get_module(basename, suffix=EXT_SUFFIX):
+def get_module(basename, suffix='.pyx'):
     return PATH.join(basename + suffix)
 
 


### PR DESCRIPTION
Rework test collection so that it's the .pyx source files that are 
collected directly, rather than the binary extension modules.

As a result, the output from pytest is more directly linked to the 
original .pyx files, e.g. whereas previously it reported each test
as coming from some .so file, it now reports like:

```
tests/example-project/src/pypackage/cython_ext_module.pyx::pypackage.cython_ext_module.Eggs.__init__ PASSED [ 16%]
tests/example-project/src/pypackage/cython_ext_module.pyx::pypackage.cython_ext_module.Eggs.blarg PASSED    [ 33%]
tests/example-project/src/pypackage/cython_ext_module.pyx::pypackage.cython_ext_module.Eggs.fubar PASSED    [ 50%]
```

As an additional benefit, it is now possible to pass the .pyx filenames
directly to pytest for doctest collection in a single file like:

```bash
$ pytest -v --doctest-cython tests/example-project/src/pypackage/cython_ext_module.pyx
```

and the fact that they are compiled to extension modules is left as an
implementation detail.

Additionally, the requirement for the embedsignature directive is
removed from the documentation.  This is not directly related to this
change, but AFAICT it is no longer necessary in modern Cython versions.
