### PR TITLE
Add CI job with Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,13 @@ jobs:
           env: TOXENV=py39-62-029
         - python: "pypy3"
           env: TOXENV=pypy3-62-029
+        - os: windows
+          env: TOXENV=py39-62-029
+          language: shell
+          before_install:
+            - choco install python --version 3.9.2
+            - python --version
+            - python -m pip install --upgrade pip
 before_install:
   - python --version
   - uname -a
@@ -30,7 +37,6 @@ before_install:
 install:
   - pip install tox
   - virtualenv --version
-  - easy_install --version
   - pip --version
   - tox --version
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,9 @@ jobs:
           env: TOXENV=pypy3-62-029
         - name: Windows - Python 3.9 - pytest 6.2 - Cython 0.29
           os: windows
-          env: TOXENV=py39-62-029
+          env:
+              - TOXENV=py39-62-029
+              - LD_PRELOAD=
           language: shell
           before_install:
             - choco install python --version 3.9.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,23 +7,32 @@ env:
     - SEGFAULT_SIGNALS=all
 jobs:
     include:
-        - python: "3.7"
+        - name: check dist
+          python: "3.7"
           env: TOXENV=check
-        - python: "3.6"
+        - name: Python 3.6 - pytest 6.2 - Cython 0.29
+          python: "3.6"
           env: TOXENV=py36-62-029
-        - python: "3.7"
+        - name: Python 3.7 - pytest 6.2 - Cython 0.29
+          python: "3.7"
           env: TOXENV=py37-62-029
-        - python: "3.8"
+        - name: Python 3.8 - pytest 6.2 - Cython 0.29
+          python: "3.8"
           env: TOXENV=py38-62-029
-        - python: "3.9"
+        - name: Python 3.9 - pytest 4.6 - Cython 0.29
+          python: "3.9"
           env: TOXENV=py39-46-029
-        - python: "3.9"
+        - name: Python 3.9 - pytest 5.4 - Cython 0.29
+          python: "3.9"
           env: TOXENV=py39-54-029
-        - python: "3.9"
+        - name: Python 3.9 - pytest 6.2 - Cython 0.29
+          python: "3.9"
           env: TOXENV=py39-62-029
-        - python: "pypy3"
+        - name: PyPy 3.x - pytest 6.2 - Cython 0.29
+          python: "pypy3"
           env: TOXENV=pypy3-62-029
-        - os: windows
+        - name: Windows - Python 3.9 - pytest 6.2 - Cython 0.29
+          os: windows
           env: TOXENV=py39-62-029
           language: shell
           before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ jobs:
           env:
               - TOXENV=py39-62-029
               - LD_PRELOAD=
+              - PATH=/c/Python39:/c/Python39/Scripts:$PATH
           language: shell
           before_install:
             - choco install python --version 3.9.2


### PR DESCRIPTION
Adds one test job against Windows.  This also obsoletes #13 since it demonstrates that other recent fixes (particularly #19) implicitly fix Windows support as well (mostly due to not explicitly checking anywhere for `.so` files).